### PR TITLE
Added --output flag support

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,12 @@ program.argument('<./file_path>', 'path of the file to process')
                                                      TemperatureChecker(options.temperature));
 
       if(response.choices[0].message.content){
-        console.log(response.choices[0].message.content)
+        if(options.output){
+          fs.writeFileSync(options.output, response.choices[0].message.content);
+          console.log(`File saved to ${options.output}`);
+        }else{
+          console.log(response.choices[0].message.content)
+        }
       }
       else{
         console.log('No explanation returned by provider.');

--- a/index.js
+++ b/index.js
@@ -15,11 +15,11 @@ program
   .description('CLI tool to process a file output the code blocks with comments')
 
 program
-  .addOption(new Option('-a, --api-key [your-key]', 'define API key to use for processing defined in .env file').env('API_KEY').makeOptionMandatory())
-  .addOption(new Option('-b, --baseURL [url]', 'define the base URL to use for processing defined in .env file').default('https://api.groq.com/').env('BASE_URL'))
-  .addOption(new Option('-m, --model [model-name]',  'define the model to use for processing').default('llama-3.1-70b-versatile').env('MODEL_NAME'))
-  .addOption(new Option('-o, --output [file.type]', 'define an output file').default('explainer_output.txt'))
-  .addOption(new Option('-t, --temperature [number]', 'define temperature of chat completion between 0 to 2').default(1).argParser(parseFloat))
+  .addOption(new Option('-a, --api-key <your-key>', 'define API key to use for processing defined in .env file').env('API_KEY').makeOptionMandatory())
+  .addOption(new Option('-b, --baseURL <url>', 'define the base URL to use for processing defined in .env file').default('https://api.groq.com/').env('BASE_URL'))
+  .addOption(new Option('-m, --model <model-name>',  'define the model to use for processing').default('llama-3.1-70b-versatile').env('MODEL_NAME'))
+  .addOption(new Option('-o, --output <file>', 'define an output file'))
+  .addOption(new Option('-t, --temperature <number>', 'define temperature of chat completion between 0 to 2').default(1).argParser(parseFloat))
   
 
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ program
   .addOption(new Option('-a, --api-key <your-key>', 'define API key to use for processing defined in .env file').env('API_KEY').makeOptionMandatory())
   .addOption(new Option('-b, --baseURL <url>', 'define the base URL to use for processing defined in .env file').default('https://api.groq.com/').env('BASE_URL'))
   .addOption(new Option('-m, --model <model-name>',  'define the model to use for processing').default('llama-3.1-70b-versatile').env('MODEL_NAME'))
-  .addOption(new Option('-o, --output <file>', 'define an output file'))
+  .addOption(new Option('-o, --output <file>', 'define an output file with valid extension to be able access the output'))
   .addOption(new Option('-t, --temperature <number>', 'define temperature of chat completion between 0 to 2').default(1).argParser(parseFloat))
   
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import 'dotenv/config';
 import { Command, Option } from "commander";
 import GroqInstance from './util/GroqInstance.js';

--- a/util/processFileWithProvider.js
+++ b/util/processFileWithProvider.js
@@ -14,7 +14,7 @@ const processFileWithProvider = async (provider, prompt, model, temperature) => 
     if (!ArgsChecker([provider, prompt, model, temperature], 4)) {
         throw new Error(`provider, prompt, model, temperature are missing or values are not defined properly`);
     }
-
+    console.log('Processing request with provider...');
     try {
         const response = await provider.chat.completions.create({
             messages: [{ role: "user", content: prompt }],


### PR DESCRIPTION
Initial plan was to implement a feature in a way so that  using `-o` would just output to a predefined file. Unfortunately, if a flag is used as Boolean it cannot have a default value of string. So, I had to remove a default value and user has to explicitly define a valid file name. 

Also updated all the options to only take argument value instead of Boolean as well. And added a console log to indicate file processing has started.  