### PR TITLE
TOML config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you are going to be defining custom Base URL and/or Model refer to [Groq Docu
   - When passing output file name, ensure it has a text readable extension such as `.txt` or `.md`. Otherwise output will not be accessible.
 - **Temperature Control**: Adjust the temperature of the model response, allowing for more or less creativity in the output. Valid temperature is between 0 to 2.
   - Higher the temperature longer the process time.
-- **TOML Config Override**: Uses a TOML config file that contains any or all of the options supported giving precedence to them over arguments provided in the CLI
+- **TOML Config Override**: Uses a TOML config file that contains any or all of the options supported giving precedence to CLI options over TOML config file options
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you are going to be defining custom Base URL and/or Model refer to [Groq Docu
   - When passing output file name, ensure it has a text readable extension such as `.txt` or `.md`. Otherwise output will not be accessible.
 - **Temperature Control**: Adjust the temperature of the model response, allowing for more or less creativity in the output. Valid temperature is between 0 to 2.
   - Higher the temperature longer the process time.
-- **TOML Config Override**: Uses a TOML config file `.explainer-config.toml` in the `home` directory that contains any or all of the options supported giving precedence to CLI options over TOML config file options
+- **TOML Config Override**: Uses a TOML config file `.explainer-config.toml` in the `home` directory that contains any or all of the options supported giving precedence to CLI options over TOML config file options.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -114,15 +114,16 @@ node index.js examples/bubble_sort.js examples/selection_sort.js
 
 You can create a [TOML](https://toml.io/en/) `.explainer-config.toml` config file that contains all of your options for the tool and place it in your `home` directory, i.e. (or simply modify and copy the one that is in the `examples directory`):
 ```toml
-# Any of these config options can or can not be provided
+# Any of these config options can or can not be provided in the .toml file
 # Feel free to place this file in your home directory, i.e: cp examples/.explainer-config.toml ~
+# Note: for the tool to work, you must provide the apiKey in either the .toml/.env files, or via the command line
 
 apiKey = "YOUR_API_KEY"
 baseURL = "https://api.groq.com/"
-temperature = 0.8 # between 0.1 and 2
+temperature = 1 # between 0 and 2
 model = "llama-3.1-70b-versatile" # any supported model
-output = "testingToml.txt" # will overwrite a file with the same name
-tokenUsage = true # can be true or false
+output = "output.txt" # will overwrite a file with the same name
+tokenUsage = false # can be true or false
 ```
 
 The tool will automatically detect and use that file if it exists, however, you do have the option to override and options in the `TOML` file using CLI options.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ node index.js examples/bubble_sort.js examples/selection_sort.js
 You can create a [TOML](https://toml.io/en/) `.explainer-config.toml` config file that contains all of your options for the tool and place it in your `home` directory, i.e. (or simply modify and copy the one that is in the `examples directory`):
 
 To copy to your home directory:
+
 ```bash
 cp examples/.explainer-config.toml ~
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you are going to be defining custom Base URL and/or Model refer to [Groq Docu
   - When passing output file name, ensure it has a text readable extension such as `.txt` or `.md`. Otherwise output will not be accessible.
 - **Temperature Control**: Adjust the temperature of the model response, allowing for more or less creativity in the output. Valid temperature is between 0 to 2.
   - Higher the temperature longer the process time.
-- **TOML Config Override**: Uses a TOML config file that contains any or all of the options supported giving precedence to CLI options over TOML config file options
+- **TOML Config Override**: Uses a TOML config file `.explainer-config.toml` in the `home` directory that contains any or all of the options supported giving precedence to CLI options over TOML config file options
 
 ## Prerequisites
 
@@ -71,7 +71,6 @@ If you are going to be defining custom Base URL and/or Model refer to [Groq Docu
 - `-u, --token-usage`: Display number of tokens that were sent in the prompt and the number of tokens that were returned. Default: `false`.
 - `-h, --help`: Display the help message for user.
 - `-v, --version`: Display the current version of the tool.
-- `-l, --toml <file>`: specify if you want to use a custom toml config file that contains all of your options
 
 ## Arguments
 
@@ -113,10 +112,10 @@ node index.js examples/bubble_sort.js examples/selection_sort.js
 
 ### TOML Config
 
-You can create a [TOML](https://toml.io/en/) config file that contains all of your options for the tool, i.e.:
+You can create a [TOML](https://toml.io/en/) `.explainer-config.toml` config file that contains all of your options for the tool and place it in your `home` directory, i.e. (or simply modify and copy the one that is in the `examples directory`):
 ```
 # Any of these config options can or can not be provided
-# Feel free to place this file anywhere, i.e: cp examples/config.toml ~/explainer-config.toml
+# Feel free to place this file in your home directory, i.e: cp examples/.explainer-config.toml ~
 
 apiKey = "YOUR_API_KEY"
 baseURL = "https://api.groq.com/"
@@ -126,17 +125,7 @@ output = "testingToml.txt" # will overwrite a file with the same name
 tokenUsage = true # can be true or false
 ```
 
-Then you may use it as follows:
-
-```bash
-node index.js --toml path/filename.toml examples/bubble_sort.js -h
-node index.js -l path/filename.toml examples/bubble_sort.js -h
-```
-
-You may also add more options to it, as in, let's say your `TOML` config file does not have a preset tokenUsage option:
-```bash
-node index.js --toml path/filename.toml examples/bubble_sort.js -u
-```
+The tool will automatically detect and use that file if it exists, however, you do have the option to override and options in the `TOML` file using CLI options.
 
 ## Version
 

--- a/README.md
+++ b/README.md
@@ -114,10 +114,16 @@ node index.js examples/bubble_sort.js examples/selection_sort.js
 
 You can create a [TOML](https://toml.io/en/) `.explainer-config.toml` config file that contains all of your options for the tool and place it in your `home` directory, i.e. (or simply modify and copy the one that is in the `examples directory`):
 
-To copy to your home directory:
+To copy to your home directory, if you're using a `Linux` environment:
 
 ```bash
 cp examples/.explainer-config.toml ~
+```
+
+If you're using a `Windows` environment:
+
+```bash
+copy examples\.explainer-config.toml %USERPROFILE%
 ```
 
 Any of these config options can or can not be provided in the .toml file, as in, you may provide one or two options in the `.toml` file, and provide the rest via the CLI!  

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ If you are going to be defining custom Base URL and/or Model refer to [Groq Docu
   - When passing output file name, ensure it has a text readable extension such as `.txt` or `.md`. Otherwise output will not be accessible.
 - **Temperature Control**: Adjust the temperature of the model response, allowing for more or less creativity in the output. Valid temperature is between 0 to 2.
   - Higher the temperature longer the process time.
+- **TOML Config Override**: Uses a TOML config file that contains any or all of the options supported giving precedence to them over arguments provided in the CLI
 
 ## Prerequisites
 
@@ -70,6 +71,7 @@ If you are going to be defining custom Base URL and/or Model refer to [Groq Docu
 - `-u, --token-usage`: Display number of tokens that were sent in the prompt and the number of tokens that were returned. Default: `false`.
 - `-h, --help`: Display the help message for user.
 - `-v, --version`: Display the current version of the tool.
+- `-l, --toml <file>`: specify if you want to use a custom toml config file that contains all of your options
 
 ## Arguments
 
@@ -107,6 +109,33 @@ or
 
 ```bash
 node index.js examples/bubble_sort.js examples/selection_sort.js
+```
+
+### TOML Config
+
+You can create a [TOML](https://toml.io/en/) config file that contains all of your options for the tool, i.e.:
+```
+# Any of these config options can or can not be provided
+# Feel free to place this file anywhere, i.e: cp examples/config.toml ~/explainer-config.toml
+
+apiKey = "YOUR_API_KEY"
+baseURL = "https://api.groq.com/"
+temperature = 0.8 # between 0.1 and 2
+model = "llama-3.1-70b-versatile" # any supported model
+output = "testingToml.txt" # will overwrite a file with the same name
+tokenUsage = true # can be true or false
+```
+
+Then you may use it as follows:
+
+```bash
+node index.js --toml path/filename.toml examples/bubble_sort.js -h
+node index.js -l path/filename.toml examples/bubble_sort.js -h
+```
+
+You may also add more options to it, as in, let's say your `TOML` config file does not have a preset tokenUsage option:
+```bash
+node index.js --toml path/filename.toml examples/bubble_sort.js -u
 ```
 
 ## Version

--- a/README.md
+++ b/README.md
@@ -113,11 +113,15 @@ node index.js examples/bubble_sort.js examples/selection_sort.js
 ### TOML Config
 
 You can create a [TOML](https://toml.io/en/) `.explainer-config.toml` config file that contains all of your options for the tool and place it in your `home` directory, i.e. (or simply modify and copy the one that is in the `examples directory`):
-```toml
-# Any of these config options can or can not be provided in the .toml file
-# Feel free to place this file in your home directory, i.e: cp examples/.explainer-config.toml ~
-# Note: for the tool to work, you must provide the apiKey in either the .toml/.env files, or via the command line
 
+To copy to your home directory:
+```bash
+cp examples/.explainer-config.toml ~
+```
+Any of these config options can or can not be provided in the .toml file, as in, you may provide one or two options in the `.toml` file, and provide the rest via the CLI!  
+`Note:` for the tool to work, you must provide the apiKey in either the `.toml`/`.env` files, or via the `command line` 
+
+```toml
 apiKey = "YOUR_API_KEY"
 baseURL = "https://api.groq.com/"
 temperature = 1 # between 0 and 2

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ node index.js examples/bubble_sort.js examples/selection_sort.js
 ### TOML Config
 
 You can create a [TOML](https://toml.io/en/) `.explainer-config.toml` config file that contains all of your options for the tool and place it in your `home` directory, i.e. (or simply modify and copy the one that is in the `examples directory`):
-```
+```toml
 # Any of these config options can or can not be provided
 # Feel free to place this file in your home directory, i.e: cp examples/.explainer-config.toml ~
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ To copy to your home directory:
 ```bash
 cp examples/.explainer-config.toml ~
 ```
+
 Any of these config options can or can not be provided in the .toml file, as in, you may provide one or two options in the `.toml` file, and provide the rest via the CLI!  
 `Note:` for the tool to work, you must provide the apiKey in either the `.toml`/`.env` files, or via the `command line` 
 

--- a/examples/.explainer-config.toml
+++ b/examples/.explainer-config.toml
@@ -4,7 +4,7 @@
 
 apiKey = "YOUR_API_KEY"
 baseURL = "https://api.groq.com/"
-temperature = 0.8 # between 0.1 and 2
+temperature = 1 # between 0 and 2
 model = "llama-3.1-70b-versatile" # any supported model
 output = "output.txt" # will overwrite a file with the same name
 tokenUsage = false # can be true or false

--- a/examples/.explainer-config.toml
+++ b/examples/.explainer-config.toml
@@ -1,7 +1,3 @@
-# Any of these config options can or can not be provided in the .toml file
-# Feel free to place this file in your home directory, i.e: cp examples/.explainer-config.toml ~
-# Note: for the tool to work, you must provide the apiKey in either the .toml/.env files, or via the command line
-
 apiKey = "YOUR_API_KEY"
 baseURL = "https://api.groq.com/"
 temperature = 1 # between 0 and 2

--- a/examples/.explainer-config.toml
+++ b/examples/.explainer-config.toml
@@ -1,5 +1,5 @@
 # Any of these config options can or can not be provided
-# Feel free to place this file anywhere, i.e: cp examples/config.toml ~/explainer-config.toml
+# Feel free to place this file in your home directory, i.e: cp examples/.explainer-config.toml ~
 
 apiKey = "YOUR_API_KEY"
 baseURL = "https://api.groq.com/"

--- a/examples/.explainer-config.toml
+++ b/examples/.explainer-config.toml
@@ -6,5 +6,5 @@ apiKey = "YOUR_API_KEY"
 baseURL = "https://api.groq.com/"
 temperature = 0.8 # between 0.1 and 2
 model = "llama-3.1-70b-versatile" # any supported model
-output = "testingToml.txt" # will overwrite a file with the same name
+output = "output.txt" # will overwrite a file with the same name
 tokenUsage = false # can be true or false

--- a/examples/.explainer-config.toml
+++ b/examples/.explainer-config.toml
@@ -1,5 +1,6 @@
-# Any of these config options can or can not be provided
+# Any of these config options can or can not be provided in the .toml file
 # Feel free to place this file in your home directory, i.e: cp examples/.explainer-config.toml ~
+# Note: for the tool to work, you must provide the apiKey in either the .toml/.env files, or via the command line
 
 apiKey = "YOUR_API_KEY"
 baseURL = "https://api.groq.com/"

--- a/examples/.explainer-config.toml
+++ b/examples/.explainer-config.toml
@@ -7,4 +7,4 @@ baseURL = "https://api.groq.com/"
 temperature = 0.8 # between 0.1 and 2
 model = "llama-3.1-70b-versatile" # any supported model
 output = "testingToml.txt" # will overwrite a file with the same name
-tokenUsage = true # can be true or false
+tokenUsage = false # can be true or false

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,0 +1,9 @@
+# Any of these config options can or can not be provided
+# Feel free to place this file anywhere, i.e: cp examples/config.toml ~/explainer-config.toml
+
+apiKey = "YOUR_API_KEY"
+baseURL = "https://api.groq.com/"
+temperature = 0.8 # between 0.1 and 2
+model = "llama-3.1-70b-versatile" # any supported model
+output = "testingToml.txt" # will overwrite a file with the same name
+tokenUsage = true # can be true or false

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ program
   .addOption(new Option('-m, --model <model-name>', 'define the model to use for processing').default('llama-3.1-70b-versatile').env('MODEL_NAME'))
   .addOption(new Option('-o, --output <file>', 'define an output file with valid extension to be able access the output'))
   .addOption(new Option('-t, --temperature <number>', 'define temperature of chat completion between 0 to 2').default(1).argParser(parseFloat))
-  .addOption(new Option('-u, --token-usage', 'specify if you want to see tokens that were sent in the prompt and the number of tokens that were returned'));
+  .addOption(new Option('-u, --token-usage', 'specify if you want to see tokens that were sent in the prompt and the number of tokens that were returned'))
 
 
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ program
   .description(packageJSON.description)
 
 program
-  .addOption(new Option('-a, --api-key <your-key>', 'define API key to use for processing defined in .env file').env('API_KEY').makeOptionMandatory())
+  .addOption(new Option('-a, --api-key <your-key>', 'define API key to use for processing defined in .env file').env('API_KEY'))
   .addOption(new Option('-b, --baseURL <url>', 'define the base URL to use for processing defined in .env file').default('https://api.groq.com/').env('BASE_URL'))
   .addOption(new Option('-m, --model <model-name>', 'define the model to use for processing').default('llama-3.1-70b-versatile').env('MODEL_NAME'))
   .addOption(new Option('-o, --output <file>', 'define an output file with valid extension to be able access the output'))

--- a/index.js
+++ b/index.js
@@ -33,12 +33,12 @@ program
     try {
       const tomlConfig = TomlChecker(options.toml);
       // check for configs provided in toml file
-      const apiKey = tomlConfig.apiKey || options.apiKey;
-      const baseURL = tomlConfig.baseURL || options.baseURL;
-      const temp = tomlConfig.temperature || options.temperature;
-      const model = tomlConfig.model || options.model;
-      const outputFile = tomlConfig.output || options.output;
-      const tokenUsage = tomlConfig.tokenUsage || options.tokenUsage;
+      const apiKey = options.apiKey || tomlConfig.apiKey;
+      const baseURL = options.baseURL || tomlConfig.baseURL;
+      const temp = options.temperature || tomlConfig.temperature;
+      const model = options.model || tomlConfig.model;
+      const outputFile = options.output || tomlConfig.output;
+      const tokenUsage = options.tokenUsage || tomlConfig.tokenUsage;      
       
       const resolvedFiles = FilePathResolver(files);
       const Groq = GroqInstance(apiKey, baseURL);

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ program
   .addOption(new Option('-o, --output <file>', 'define an output file with valid extension to be able access the output'))
   .addOption(new Option('-t, --temperature <number>', 'define temperature of chat completion between 0 to 2').default(1).argParser(parseFloat))
   .addOption(new Option('-u, --token-usage', 'specify if you want to see tokens that were sent in the prompt and the number of tokens that were returned'))
+  .addOption(new Option('-l, --toml', 'specify if you want to use a custom toml config file that contains all of your options'));
 
 
 

--- a/index.js
+++ b/index.js
@@ -22,8 +22,7 @@ program
   .addOption(new Option('-m, --model <model-name>', 'define the model to use for processing').default('llama-3.1-70b-versatile').env('MODEL_NAME'))
   .addOption(new Option('-o, --output <file>', 'define an output file with valid extension to be able access the output'))
   .addOption(new Option('-t, --temperature <number>', 'define temperature of chat completion between 0 to 2').default(1).argParser(parseFloat))
-  .addOption(new Option('-u, --token-usage', 'specify if you want to see tokens that were sent in the prompt and the number of tokens that were returned'))
-  .addOption(new Option('-l, --toml <file>', 'specify if you want to use a custom toml config file that contains all of your options'));
+  .addOption(new Option('-u, --token-usage', 'specify if you want to see tokens that were sent in the prompt and the number of tokens that were returned'));
 
 
 
@@ -31,7 +30,7 @@ program
   program.argument('<files...>', 'path of the files or directories to process')
   .action(async (files, options) => {
     try {
-      const tomlConfig = TomlChecker(options.toml);
+      const tomlConfig = TomlChecker();
       // check for configs provided in toml file
       const apiKey = options.apiKey || tomlConfig.apiKey;
       const baseURL = options.baseURL || tomlConfig.baseURL;

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ program
   .action(async (files, options) => {
     try {
       const tomlConfig = TomlChecker();
-      // check for configs provided in toml file
+      
       const apiKey = options.apiKey || tomlConfig.apiKey;
       const baseURL = options.baseURL || tomlConfig.baseURL;
       const temp = options.temperature || tomlConfig.temperature;

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import BuildFilePrompt from './util/BuildFilePrompt.js';
 import ProcessFileWithProvider from './util/ProcessFileWithProvider.js';
 import TemperatureChecker from './util/TemperatureChecker.js';
 import FilePathResolver from './util/FilePathResolver.js';
+import TomlChecker from './util/TomlChecker.js';
 
 const packageJSON = JSON.parse(fs.readFileSync('./package.json'));
 const program = new Command();
@@ -22,7 +23,7 @@ program
   .addOption(new Option('-o, --output <file>', 'define an output file with valid extension to be able access the output'))
   .addOption(new Option('-t, --temperature <number>', 'define temperature of chat completion between 0 to 2').default(1).argParser(parseFloat))
   .addOption(new Option('-u, --token-usage', 'specify if you want to see tokens that were sent in the prompt and the number of tokens that were returned'))
-  .addOption(new Option('-l, --toml', 'specify if you want to use a custom toml config file that contains all of your options'));
+  .addOption(new Option('-l, --toml <file>', 'specify if you want to use a custom toml config file that contains all of your options'));
 
 
 
@@ -30,6 +31,7 @@ program
   program.argument('<files...>', 'path of the files or directories to process')
   .action(async (files, options) => {
     try {
+      TomlChecker(options.toml);
       const resolvedFiles = FilePathResolver(files);
       const Groq = GroqInstance(options.apiKey, options.baseURL);
       const Temperature = TemperatureChecker(options.temperature);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,17 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@ltd/j-toml": "^1.38.0",
         "commander": "^12.1.0",
         "dotenv": "^16.4.5",
         "groq-sdk": "^0.7.0"
       }
+    },
+    "node_modules/@ltd/j-toml": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@ltd/j-toml/-/j-toml-1.38.0.tgz",
+      "integrity": "sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw==",
+      "license": "LGPL-3.0"
     },
     "node_modules/@types/node": {
       "version": "18.19.50",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/aamfahim/explainer.js#readme",
   "dependencies": {
+    "@ltd/j-toml": "^1.38.0",
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
     "groq-sdk": "^0.7.0"

--- a/util/TomlChecker.js
+++ b/util/TomlChecker.js
@@ -1,32 +1,30 @@
-import * as TOML from '@ltd/j-toml'
+import * as TOML from '@ltd/j-toml';
 import * as os from 'os';
 import path from 'path';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 
 /**
- * Checks if the provided Toml file is valid and returns the options in it.
+ * Checks if the .explainer-config.toml file exists in the user's home directory,
+ * and returns the options in it if valid. Returns an empty object if the file doesn't exist.
  *
- * @param {string} tomlFile - the full file path/name of the TOML file provided by the user.
- * @returns {Record<string, any>} - An object containing as attributes all the options in the provided TOML file.
- * @throws {Error} - If the file provided cannot be read, not a valid TOML file, or does not exist.
+ * @returns {Record<string, any>} - An object containing attributes from the TOML file, or an empty object if the file doesn't exist.
+ * @throws {Error} - If the file exists but cannot be parsed as a valid TOML file.
  */
-const TomlChecker = (tomlFile) => {
-    let config = {};
+const TomlChecker = () => {
+    const tomlFile = path.join(os.homedir(), '.explainer-config.toml');
 
-    if(tomlFile)
-    {
-        if(tomlFile.startsWith('~'))
-        {
-            tomlFile = path.join(os.homedir(), tomlFile.slice(1));
-        }
+    if (!existsSync(tomlFile)) {
+        return {};
+    }
 
+    try {
         const finalPath = path.resolve(tomlFile);
         const fileContents = readFileSync(finalPath, 'utf8');
-        config = TOML.parse(fileContents);
-
-        return config;
+        return TOML.parse(fileContents);
+    } catch (err) {
+        console.error('Error parsing the TOML file:', err);
+        process.exit(1);
     }
-    return config;
 };
 
 export default TomlChecker;

--- a/util/TomlChecker.js
+++ b/util/TomlChecker.js
@@ -17,9 +17,16 @@ const TomlChecker = () => {
         return {};
     }
 
-    const finalPath = path.resolve(tomlFile);
-    const fileContents = readFileSync(finalPath, 'utf8');
-    return TOML.parse(fileContents);
+    try{
+        const finalPath = path.resolve(tomlFile);
+        const fileContents = readFileSync(finalPath, 'utf8');
+        return TOML.parse(fileContents);
+    }
+    catch(err)
+    {
+        throw new Error(`TOML parsing failed:`, err);
+    }
+
 };
 
 export default TomlChecker;

--- a/util/TomlChecker.js
+++ b/util/TomlChecker.js
@@ -1,0 +1,30 @@
+import * as TOML from '@ltd/j-toml'
+import * as os from 'os';
+import path from 'path';
+import { readFileSync } from 'fs';
+
+const TomlChecker = (tomlFile) => {
+
+    let config = {};
+
+    if(tomlFile)
+    {
+        if(tomlFile.startsWith('~'))
+        {
+            tomlFile = path.join(os.homedir(), tomlFile.slice(1));
+        }
+
+        const finalPath = path.resolve(tomlFile);
+
+        const fileContents = readFileSync(finalPath, 'utf8');
+
+        config = TOML.parse(fileContents);
+
+        return config;
+    }
+
+
+    return config;
+};
+
+export default TomlChecker;

--- a/util/TomlChecker.js
+++ b/util/TomlChecker.js
@@ -1,5 +1,5 @@
-import * as TOML from '@ltd/j-toml';
-import * as os from 'os';
+import TOML from '@ltd/j-toml';
+import os from 'os';
 import path from 'path';
 import { readFileSync, existsSync } from 'fs';
 

--- a/util/TomlChecker.js
+++ b/util/TomlChecker.js
@@ -22,9 +22,9 @@ const TomlChecker = () => {
         const fileContents = readFileSync(finalPath, 'utf8');
         return TOML.parse(fileContents);
     }
-    catch(err)
+    catch(error)
     {
-        throw new Error(`TOML parsing failed:`, err);
+        throw new Error(`TOML parsing failed:`, error);
     }
 
 };

--- a/util/TomlChecker.js
+++ b/util/TomlChecker.js
@@ -3,6 +3,13 @@ import * as os from 'os';
 import path from 'path';
 import { readFileSync } from 'fs';
 
+/**
+ * Checks if the provided Toml file is valid and returns the options in it.
+ *
+ * @param {string} tomlFile - the full file path/name of the TOML file provided by the user.
+ * @returns {Record<string, any>} - An object containing as attributes all the options in the provided TOML file.
+ * @throws {Error} - If the file provided cannot be read, not a valid TOML file, or does not exist.
+ */
 const TomlChecker = (tomlFile) => {
     let config = {};
 

--- a/util/TomlChecker.js
+++ b/util/TomlChecker.js
@@ -4,7 +4,6 @@ import path from 'path';
 import { readFileSync } from 'fs';
 
 const TomlChecker = (tomlFile) => {
-
     let config = {};
 
     if(tomlFile)
@@ -15,15 +14,11 @@ const TomlChecker = (tomlFile) => {
         }
 
         const finalPath = path.resolve(tomlFile);
-
         const fileContents = readFileSync(finalPath, 'utf8');
-
         config = TOML.parse(fileContents);
 
         return config;
     }
-
-
     return config;
 };
 

--- a/util/TomlChecker.js
+++ b/util/TomlChecker.js
@@ -17,14 +17,9 @@ const TomlChecker = () => {
         return {};
     }
 
-    try {
-        const finalPath = path.resolve(tomlFile);
-        const fileContents = readFileSync(finalPath, 'utf8');
-        return TOML.parse(fileContents);
-    } catch (err) {
-        console.error('Error parsing the TOML file:', err);
-        process.exit(1);
-    }
+    const finalPath = path.resolve(tomlFile);
+    const fileContents = readFileSync(finalPath, 'utf8');
+    return TOML.parse(fileContents);
 };
 
 export default TomlChecker;

--- a/util/TomlChecker.js
+++ b/util/TomlChecker.js
@@ -24,7 +24,7 @@ const TomlChecker = () => {
     }
     catch(error)
     {
-        throw new Error(`TOML parsing failed:`, error);
+        throw new Error(`TOML parsing failed: ${error.message}`);
     }
 
 };


### PR DESCRIPTION
# Description

Closes #28.

Added a new feature to support config options provided by a [TOML](https://toml.io/en/) `.explainer-config.toml` file in the `home` directory: 
- All options provided by the config file will only work if no equivalent option is given in the CLI, as the CLI takes precedence over `TOML`. 
- Used [j-toml](https://github.com/LongTengDao/j-toml/tree/master/docs/English) as the `TOML` file parser.
- Added an example of a `TOML` config file in the `examples` folder.
- Updated `README.md` to explain the new feature.

## Testing

Visit the new `TOMl` file added in the `examples` folder, and add your `API_KEY` in there, i.e.:

```
# Any of these config options can or can not be provided
# Feel free to place this file in your home directory, i.e: cp examples/.explainer-config.toml ~

apiKey = "YOUR_API_KEY"
baseURL = "https://api.groq.com/"
temperature = 0.8 # between 0.1 and 2
model = "llama-3.1-70b-versatile" # any supported model
output = "testingToml.txt" # will overwrite a file with the same name
tokenUsage = true # can be true or false
```

Then copy it to your `home` directory.

### Test 1

Use `explainer` with the `TOML` file, i.e.:
```bash
node index.js examples/bubble_sort.js
```

Make sure that all the flags have been processed

### Test 2

Try different combinations in the `TOML` config file, i.e.:

```
temperature = 0.8 # between 0.1 and 2
model = "llama-3.1-70b-versatile" # any supported model
output = "testingToml.txt" # will overwrite a file with the same name
```

And provide extra options in the CLI tool, i.e.:

```bash
node index.js examples/bubble_sort.js -u
```

This should not only process the options in the `TOML` file, but also the `-u` token usage flag

### Test 3

Try to override configs given in the `TOML` file, i.e., let's say your `TOML` file is:

```
temperature = 0.8 # between 0.1 and 2
model = "llama-3.1-70b-versatile" # any supported model
output = "testingToml.txt" # will overwrite a file with the same name
```

But you provide a different temperature when using the tool, i.e.:

```bash
node index.js examples/bubble_sort.js -t 0.9
```
It should use the CLI given temperature instead.

